### PR TITLE
Make mehd box optional

### DIFF
--- a/src/fmp4/initialization.rs
+++ b/src/fmp4/initialization.rs
@@ -69,7 +69,7 @@ impl Mp4Box for MovieBox {
         track_assert!(!self.trak_boxes.is_empty(), ErrorKind::InvalidInput);
         write_box!(writer, self.mvhd_box);
         write_boxes!(writer, &self.trak_boxes);
-        write_box!(writer, self.mvex_box);
+        write_box!(writer, &self.mvex_box);
         Ok(())
     }
 }
@@ -78,7 +78,7 @@ impl Mp4Box for MovieBox {
 #[allow(missing_docs)]
 #[derive(Debug, Default)]
 pub struct MovieExtendsBox {
-    pub mehd_box: MovieExtendsHeaderBox,
+    pub mehd_box: Option<MovieExtendsHeaderBox>,
     pub trex_boxes: Vec<TrackExtendsBox>,
 }
 impl Mp4Box for MovieExtendsBox {
@@ -86,13 +86,15 @@ impl Mp4Box for MovieExtendsBox {
 
     fn box_payload_size(&self) -> Result<u32> {
         let mut size = 0;
-        size += box_size!(self.mehd_box);
+        size += optional_box_size!(self.mehd_box);
         size += boxes_size!(self.trex_boxes);
         Ok(size)
     }
     fn write_box_payload<W: Write>(&self, mut writer: W) -> Result<()> {
         track_assert!(!self.trex_boxes.is_empty(), ErrorKind::InvalidInput);
-        write_box!(writer, self.mehd_box);
+        if let Some(mehd_box) = &self.mehd_box {
+            write_box!(writer, mehd_box);
+        }
         write_boxes!(writer, &self.trex_boxes);
         Ok(())
     }

--- a/src/mpeg2_ts.rs
+++ b/src/mpeg2_ts.rs
@@ -5,8 +5,8 @@ use crate::avc::{
 };
 use crate::fmp4::{
     AacSampleEntry, AvcConfigurationBox, AvcSampleEntry, InitializationSegment, MediaDataBox,
-    MediaSegment, Mp4Box, Mpeg4EsDescriptorBox, Sample, SampleEntry, SampleFlags, TrackBox,
-    TrackExtendsBox, TrackFragmentBox,
+    MediaSegment, MovieExtendsHeaderBox, Mp4Box, Mpeg4EsDescriptorBox, Sample, SampleEntry,
+    SampleFlags, TrackBox, TrackExtendsBox, TrackFragmentBox,
 };
 use crate::io::ByteCounter;
 use crate::{Error, ErrorKind, Result};
@@ -40,11 +40,15 @@ fn make_initialization_segment(
     if video_duration < audio_duration {
         segment.moov_box.mvhd_box.timescale = aac::SAMPLES_IN_FRAME as u32;
         segment.moov_box.mvhd_box.duration = audio_duration;
-        segment.moov_box.mvex_box.mehd_box.fragment_duration = audio_duration;
+        segment.moov_box.mvex_box.mehd_box = Some(MovieExtendsHeaderBox {
+            fragment_duration: audio_duration,
+        });
     } else {
         segment.moov_box.mvhd_box.timescale = Timestamp::RESOLUTION as u32;
         segment.moov_box.mvhd_box.duration = video_duration;
-        segment.moov_box.mvex_box.mehd_box.fragment_duration = video_duration;
+        segment.moov_box.mvex_box.mehd_box = Some(MovieExtendsHeaderBox {
+            fragment_duration: video_duration,
+        });
     }
 
     // video track


### PR DESCRIPTION
According to the spec:

>The Movie Extends Header is optional, and provides the overall
>duration, including fragments, of a fragmented movie.  If this
>box is not present, the overall duration must be computed by
>examining each fragment.
>
>..
>
>If an MP4 file is created in real-time, such as used in live
>streaming, it is not likely that the fragment_duration is known
>in advance and this box may be omitted.